### PR TITLE
Menu improvements + fixes, renames, and more theme slop

### DIFF
--- a/Classes/ArchiveList.js
+++ b/Classes/ArchiveList.js
@@ -13,7 +13,7 @@ class ArchiveList extends List {
             ctx.shadowColor = theme.getPaint("Glow").getHex();
             ctx.shadowOffsetX = 0.7;
             ctx.shadowOffsetY = 0.7;
-            ctx.shadowBlur = 1;
+            ctx.shadowBlur = 1 * theme.getData("GlowIntensity");
         }
 
         strokeWeight(5)

--- a/Classes/ArchiveList.js
+++ b/Classes/ArchiveList.js
@@ -9,25 +9,27 @@ class ArchiveList extends List {
 
     show(x) {
         let ctx = drawingContext
-        ctx.shadowColor = theme.getColor("Glow").toHex();
-        ctx.shadowOffsetX = 0.7;
-        ctx.shadowOffsetY = 0.7;
-        ctx.shadowBlur = 1;
+        if (theme.getData("GlowEnabled")) {
+            ctx.shadowColor = theme.getPaint("Glow").getHex();
+            ctx.shadowOffsetX = 0.7;
+            ctx.shadowOffsetY = 0.7;
+            ctx.shadowBlur = 1;
+        }
 
         strokeWeight(5)
 
-        let borderColor = theme.getColor("StrokePrimary")
-        let backgroundColor = theme.getColor("BackgroundSecondary")
-        let titleColor = theme.getColor("TextPrimary")
+        let borderColor = theme.getPaint("StrokePrimary")
+        let backgroundColor = theme.getPaint("BackgroundSecondary")
+        let titleColor = theme.getPaint("TextPrimary")
 
         if (mode === "default") {
-            stroke(borderColor.getColor());
-            fill(backgroundColor.getColor());
+            stroke(borderColor.getRGB());
+            fill(backgroundColor.getRGB());
         } else if (mode === "dark") {
             let evilmodeColor = backgroundColor.toDarkMode()
             let evilBorderColor = borderColor.toDarkMode()
-            stroke(evilBorderColor.getColor());
-            fill(evilmodeColor.getColor());
+            stroke(evilBorderColor.getRGB());
+            fill(evilmodeColor.getRGB());
         }
         // box
         let verticalOffsetTop = 100;
@@ -49,18 +51,18 @@ class ArchiveList extends List {
 
         // title
         
-        textFont(theme.getFont());
+        textFont(theme.getData("Font"));
         textAlign(CENTER, CENTER);
       
        
         
         if (mode === "default") {
             strokeWeight(0);
-            fill(titleColor.getColor());
+            fill(titleColor.getRGB());
         } else if (mode === "dark") {
             let evilTitleColor = titleColor.toDarkMode()
             strokeWeight(3);
-            fill(evilTitleColor.getColor());
+            fill(evilTitleColor.getRGB());
         }
         textSize(24);
       

--- a/Classes/Bar.js
+++ b/Classes/Bar.js
@@ -56,22 +56,24 @@ class Bar{
 
     show(){
         let ctx = drawingContext
-        ctx.shadowColor = theme.getColor("Glow").toHex();
-        ctx.shadowOffsetX = 0.7;
-        ctx.shadowOffsetY = 0.7;
-        ctx.shadowBlur = 1;
+        if (theme.getData("GlowEnabled")) {
+            ctx.shadowColor = theme.getPaint("Glow").getHex();
+            ctx.shadowOffsetX = 0.7;
+            ctx.shadowOffsetY = 0.7;
+            ctx.shadowBlur = 1;
+        }
 
         strokeWeight(5)
 
-        let bgColor = theme.getColor("BackgroundSecondary");
-        let borderColor = theme.getColor("StrokePrimary")
+        let bgColor = theme.getPaint("BackgroundSecondary");
+        let borderColor = theme.getPaint("StrokePrimary")
         
         if (mode === "default") {
-            stroke(borderColor.getColor());
-            fill(bgColor.getColor());
+            stroke(borderColor.getRGB());
+            fill(bgColor.getRGB());
         } else if (mode === "dark") {
-            stroke(borderColor.toDarkMode().getColor());
-            fill(bgColor.toDarkMode().getColor());
+            stroke(borderColor.toDarkMode().getRGB());
+            fill(bgColor.toDarkMode().getRGB());
         }
         
         rect(this.x, this.y, this.width, this.height, this.cornerCouverture);

--- a/Classes/Bar.js
+++ b/Classes/Bar.js
@@ -60,7 +60,7 @@ class Bar{
             ctx.shadowColor = theme.getPaint("Glow").getHex();
             ctx.shadowOffsetX = 0.7;
             ctx.shadowOffsetY = 0.7;
-            ctx.shadowBlur = 1;
+            ctx.shadowBlur = 1 * theme.getData("GlowIntensity");
         }
 
         strokeWeight(5)

--- a/Classes/List.js
+++ b/Classes/List.js
@@ -12,9 +12,9 @@ class List {
             105,
             this
         );
-        this.titleColor = theme.getColor("TextPrimary")
-        this.backgroundColor = theme.getColor("BackgroundSecondary")
-        this.borderColor = theme.getColor("StrokePrimary")
+        this.titleColor = theme.getPaint("TextPrimary")
+        this.backgroundColor = theme.getPaint("BackgroundSecondary")
+        this.borderColor = theme.getPaint("StrokePrimary")
     }
 
     //Getters
@@ -184,23 +184,25 @@ class List {
         this.x = x; // this is necessary for the List's menu
         
         let ctx = drawingContext
-        ctx.shadowColor = theme.getColor("Glow").toHex();
-        ctx.shadowOffsetX = 0.7;
-        ctx.shadowOffsetY = 0.7;
-        ctx.shadowBlur = 1;
+        if (theme.getData("GlowEnabled")) {
+            ctx.shadowColor = theme.getPaint("Glow").getHex();
+            ctx.shadowOffsetX = 0.7;
+            ctx.shadowOffsetY = 0.7;
+            ctx.shadowBlur = 1;
+        }
 
-        let borderColor = theme.getColor("StrokePrimary")
-        let backgroundColor = theme.getColor("BackgroundSecondary")
-        let titleColor = theme.getColor("TextPrimary")
+        let borderColor = theme.getPaint("StrokePrimary")
+        let backgroundColor = theme.getPaint("BackgroundSecondary")
+        let titleColor = theme.getPaint("TextPrimary")
 
         if (mode === "default") {
-            stroke(borderColor.getColor());
-            fill(backgroundColor.getColor());
+            stroke(borderColor.getRGB());
+            fill(backgroundColor.getRGB());
         } else if (mode === "dark") {
             let evilmodeColor = backgroundColor.toDarkMode()
             let evilBorderColor = borderColor.toDarkMode()
-            stroke(evilBorderColor.getColor());
-            fill(evilmodeColor.getColor());
+            stroke(evilBorderColor.getRGB());
+            fill(evilmodeColor.getRGB());
         }
         // box
         strokeWeight(5);
@@ -220,20 +222,20 @@ class List {
 
         // title
         strokeWeight(0)
-        textFont(theme.getFont());
+        textFont(theme.getData("Font"));
         textAlign(CENTER, CENTER);
         if (mode === "default") {
             strokeWeight(0);
-            fill(titleColor.getColor());
+            fill(titleColor.getRGB());
         } else if (mode === "dark") {
             let evilTitleColor = titleColor.toDarkMode()
             strokeWeight(3);
-            fill(evilTitleColor.getColor());
+            fill(evilTitleColor.getRGB());
         }
         textSize(24);
         
         text(this.name, x + 200, verticalOffsetTop + 20);
-        // fill(this.backgroundColor.getColor());
+        // fill(this.backgroundColor.getRGB());
         textSize(12);
         strokeWeight(1);
 

--- a/Classes/List.js
+++ b/Classes/List.js
@@ -6,12 +6,13 @@ class List {
         this.listStorage = [];
 
         this.menu = new Menu(
-            0,
-            0, 
+            30,
+            105, 
             100, 
             105,
             this
         );
+        
         this.titleColor = theme.getPaint("TextPrimary")
         this.backgroundColor = theme.getPaint("BackgroundSecondary")
         this.borderColor = theme.getPaint("StrokePrimary")
@@ -188,7 +189,7 @@ class List {
             ctx.shadowColor = theme.getPaint("Glow").getHex();
             ctx.shadowOffsetX = 0.7;
             ctx.shadowOffsetY = 0.7;
-            ctx.shadowBlur = 1;
+            ctx.shadowBlur = 1 * theme.getData("GlowIntensity");
         }
 
         let borderColor = theme.getPaint("StrokePrimary")
@@ -214,8 +215,19 @@ class List {
         ctx.shadowOffsetY = 0;
         ctx.shadowBlur = 0;
 
+        this.menu.x = x + 30
+
         //sets pos of buttons
         this.menu.menuButton.position(x + 370,verticalOffsetBottom - 17);
+
+        //styles the menu button
+        let buttonBg = theme.getPaint("BackgroundSecondary")
+        let buttonText = theme.getPaint("TextPrimary")
+        let buttonStroke = theme.getPaint("StrokePrimary")
+
+        this.menu.menuButton.style("background-color", buttonBg.getHex()); 
+        this.menu.menuButton.style("color", buttonText.getHex()); 
+        this.menu.menuButton.style("border", "2px solid" + buttonStroke.getHex()); 
 
         //show move task up/down buttons
         this.menu.menuButton.show();
@@ -245,7 +257,7 @@ class List {
             this.showTasks(x)
         }
 
-        this.menu.showListMenu();
+        this.menu.showMenu();
     }
 
     showTasks(x) {

--- a/Classes/Menu.js
+++ b/Classes/Menu.js
@@ -195,8 +195,8 @@ class Menu {
         if (!this.taskMenuOpen) {
             return;
         }
-        let bgColor = theme.getColor("BackgroundTertiary")
-        let borderColor = theme.getColor("StrokeSecondary")
+        let bgColor = theme.getPaint("BackgroundTertiary")
+        let borderColor = theme.getPaint("StrokeSecondary")
         const pos = { x: this.x, y: this.y };
 
         // main box
@@ -205,11 +205,11 @@ class Menu {
         this.mainBox.style(`height: ${[this.height]}px`);
         this.mainBox.style("z-index: 2");
         if (mode === "default") {
-            this.mainBox.style(`background-color: ${bgColor.toHex()}`);
-            this.mainBox.style(`border: 3px solid ${borderColor.toHex()}`);
+            this.mainBox.style(`background-color: ${bgColor.getHex()}`);
+            this.mainBox.style(`border: 3px solid ${borderColor.getHex()}`);
         } else if (mode === "dark") {
-            this.mainBox.style(`background-color: ${bgColor.toDarkMode().toHex()}`);
-            this.mainBox.style(`border: 3px solid ${borderColor.toHex()}`);
+            this.mainBox.style(`background-color: ${bgColor.toDarkMode().getHex()}`);
+            this.mainBox.style(`border: 3px solid ${borderColor.getHex()}`);
         }
 
         this.mainBox.style(`border-radius: 10px`);
@@ -230,16 +230,16 @@ class Menu {
             this.moveTaskDownButton
         ]
         
-        let bgClr = theme.getColor("BackgroundSecondary")
-        let textClr = theme.getColor("TextPrimary")
-        let strokeClr = theme.getColor("StrokePrimary")
+        let bgClr = theme.getPaint("BackgroundSecondary")
+        let textClr = theme.getPaint("TextPrimary")
+        let strokeClr = theme.getPaint("StrokePrimary")
         for (let btn of buttons) {
             btn.show()
             btn.style('z-index', '3')
             btn.style('position', 'absolute')
-            btn.style("background-color", bgClr.toHex()); 
-            btn.style("color", textClr.toHex()); 
-            btn.style("border", "2px solid" + strokeClr.toHex()); 
+            btn.style("background-color", bgClr.getHex()); 
+            btn.style("color", textClr.getHex()); 
+            btn.style("border", "2px solid" + strokeClr.getHex()); 
         }
     }
 
@@ -248,8 +248,8 @@ class Menu {
         if (!this.listMenuOpen) {
             return;
         }
-        let bgColor = theme.getColor("BackgroundTertiary")
-        let borderColor = theme.getColor("StrokeSecondary")
+        let bgColor = theme.getPaint("BackgroundTertiary")
+        let borderColor = theme.getPaint("StrokeSecondary")
         const pos = { x: this.parent.x, y: this.y };
 
         // main box
@@ -258,11 +258,11 @@ class Menu {
         this.mainBox.style(`height: ${[this.height]}px`);
         this.mainBox.style("z-index: 2");
         if (mode === "default") {
-            this.mainBox.style(`background-color: ${bgColor.toHex()}`);
-            this.mainBox.style(`border: 3px solid ${borderColor.toHex()}`);
+            this.mainBox.style(`background-color: ${bgColor.getHex()}`);
+            this.mainBox.style(`border: 3px solid ${borderColor.getHex()}`);
         } else if (mode === "dark") {
-            this.mainBox.style(`background-color: ${bgColor.toDarkMode().toHex()}`);
-            this.mainBox.style(`border: 3px solid ${borderColor.toHex()}`);
+            this.mainBox.style(`background-color: ${bgColor.toDarkMode().getHex()}`);
+            this.mainBox.style(`border: 3px solid ${borderColor.getHex()}`);
         }
 
         this.mainBox.style(`border-radius: 10px`);
@@ -295,16 +295,16 @@ class Menu {
             this.moveTaskDownButton
         ]
         
-        let bgClr = theme.getColor("BackgroundSecondary")
-        let textClr = theme.getColor("TextPrimary")
-        let strokeClr = theme.getColor("StrokePrimary")
+        let bgClr = theme.getPaint("BackgroundSecondary")
+        let textClr = theme.getPaint("TextPrimary")
+        let strokeClr = theme.getPaint("StrokePrimary")
         for (let btn of buttons) {
             btn.show()
             btn.style('z-index', '3')
             btn.style('position', 'absolute')
-            btn.style("background-color", bgClr.toHex()); 
-            btn.style("color", textClr.toHex()); 
-            btn.style("border", "2px solid" + strokeClr.toHex()); 
+            btn.style("background-color", bgClr.getHex()); 
+            btn.style("color", textClr.getHex()); 
+            btn.style("border", "2px solid" + strokeClr.getHex()); 
         }
     }
 

--- a/Classes/Menu.js
+++ b/Classes/Menu.js
@@ -6,7 +6,6 @@ const LIST_MENU_X_OFFSET = 395;
 const LIST_MENU_Y_OFFSET = 105;
 
 class Menu {
-
     constructor(x, y, width, height, parent) {
         this.x = x;
         this.y = y;
@@ -17,45 +16,61 @@ class Menu {
         this.parent = parent;
 
         //task buttons
-        this.markTaskDoneButton = createButton(`Mark Done`);
-        this.markTaskDoneButton.hide();
-        this.markTaskDoneButton.mousePressed(() => this.buttonPressedMarkDone());
+        if (parent instanceof Task) {
+            this.markTaskDoneButton = createButton(`Mark Done`);
+            this.markTaskDoneButton.hide();
+            this.markTaskDoneButton.mousePressed(() => this.buttonPressedMarkDone());
 
-        this.deleteTaskButton = createButton(`Delete Task`);
-        this.deleteTaskButton.hide();
-        this.deleteTaskButton.mousePressed(() => this.buttonPressedDelete());
+            this.deleteTaskButton = createButton(`Delete Task`);
+            this.deleteTaskButton.hide();
+            this.deleteTaskButton.mousePressed(() => this.buttonPressedDelete());
 
-        this.editTaskButton = createButton(`Edit Task`);
-        this.editTaskButton.hide();
-        this.editTaskButton.mousePressed(() => this.editTask());
+            this.editTaskButton = createButton(`Edit Task`);
+            this.editTaskButton.hide();
+            this.editTaskButton.mousePressed(() => this.editTask());
 
-        this.moveTaskUpButton = createButton(`⬆️`);
-        this.moveTaskUpButton.hide();
-        this.moveTaskUpButton.mousePressed(() => this.slidePosition(1));
+            this.moveTaskUpButton = createButton(`⬆️`);
+            this.moveTaskUpButton.hide();
+            this.moveTaskUpButton.mousePressed(() => this.slidePosition(1));
 
-        this.moveTaskDownButton = createButton(`⬇️`);
-        this.moveTaskDownButton.hide();
-        this.moveTaskDownButton.mousePressed(() => this.slidePosition(-1));
+            this.moveTaskDownButton = createButton(`⬇️`);
+            this.moveTaskDownButton.hide();
+            this.moveTaskDownButton.mousePressed(() => this.slidePosition(-1));
 
+            this.buttons = [
+                this.markTaskDoneButton,
+                this.editTaskButton,
+                this.deleteTaskButton,
+                this.moveTaskUpButton,
+                this.moveTaskDownButton
+            ]
+        }
+        else if (parent instanceof List) {
+            //list buttons
+            this.addTaskButton = createButton(`Add Task`);
+            this.addTaskButton.hide();
+            this.addTaskButton.mousePressed(() => this.buttonPressedAddTask());
+            
+            this.deleteListButton = createButton(`Delete List`);
+            this.deleteListButton.hide();
+            this.deleteListButton.mousePressed(() => this.buttonPressedDeleteList());
+            
+            this.editListButton = createButton(`Edit List`);
+            this.editListButton.hide();
+            this.editListButton.mousePressed(() => this.editList());
+
+            this.buttons = [
+                this.addTaskButton,
+                this.deleteListButton,
+                this.editListButton
+            ]
+        }
+    
         this.menuButton = createButton(`≡`);
         this.menuButton.hide();
         this.menuButton.mousePressed(() => this.buttonPressedMenu());
 
-        //list buttons
-        this.addTaskButton = createButton(`Add Task`);
-        this.addTaskButton.hide();
-        this.addTaskButton.mousePressed(() => this.buttonPressedAddTask());
-
-        this.deleteListButton = createButton(`Delete List`);
-        this.deleteListButton.hide();
-        this.deleteListButton.mousePressed(() => this.buttonPressedDeleteList());
-
-        this.editListButton = createButton(`Edit List`);
-        this.editListButton.hide();
-        this.editListButton.mousePressed(() => this.editList());
-
         this.mainBox = createDiv();
-
     }
 
     deleteMenu() {
@@ -91,15 +106,15 @@ class Menu {
         saveAllLists();
     }
 
-    deleteListButtons(){
-        this.addTaskButton.remove();
-        this.deleteListButton.remove();
-        this.editListButton.remove();
-        this.menuButton.remove();
+    deleteButtons(){
+        for (button of this.buttons) {
+            button.remove()
+        }
+        this.deleteListTaskButtons();
     }
 
     buttonPressedDeleteList(){
-        this.deleteListButtons();
+        this.deleteButtons();
         this.deleteListTaskButtons();
         this.mainBox.remove();
         localStorage.clear();
@@ -117,16 +132,11 @@ class Menu {
 
     editList(){
         let editName = prompt("Input new list name:", this.parent.name);
-        switch(editName){
-            case null:
-                return;
-            break;
-
-            default:
-                this.parent.name = editName;
-                saveAllLists();
+        if (editName) {
+            this.parent.name = editName;
+            saveAllLists();
         }
-
+        
         hideAllMenus();
     }
 
@@ -146,53 +156,24 @@ class Menu {
     }
 
     closeMenu() {
-        if(this.parent instanceof Task){
-            this.taskMenuOpen = false;
-            this.hideMenuButtons();
+            this.menuOpen = false;
+            this.hideButtons();
+            this.mainBox.hide()
             return;
-        }else if(this.parent instanceof List){
-            this.listMenuOpen = false;
-            this.hideListMenuButtons();
-            return;
-        }
-        
-        
     }
 
     buttonPressedMenu() {
-        if(this.parent instanceof Task){
-           if (!this.taskMenuOpen) {
+           if (!this.menuOpen) {
                 hideAllMenus()
-                this.taskMenuOpen = true;
+                this.menuOpen = true;
                 return;
-            } else if (this.taskMenuOpen) {
+            } else if (this.menuOpen) {
                 this.closeMenu();
             } 
-        }else if(this.parent instanceof List){
-            if (!this.listMenuOpen) {
-                hideAllMenus()
-                this.listMenuOpen = true;
-                return;
-            } else if (this.listMenuOpen) {
-                this.closeMenu();
-            } 
-        }
-        
-
     }
 
-    deleteTaskButtons() {
-        this.moveTaskUpButton.remove();
-        this.moveTaskDownButton.remove();
-        this.markTaskDoneButton.remove();
-        this.deleteTaskButton.remove();
-        this.editTaskButton.remove();
-        this.menuButton.remove();
-    }
-
-    showTaskMenu() {
-
-        if (!this.taskMenuOpen) {
+    showMenu() {
+        if (!this.menuOpen) {
             return;
         }
         let bgColor = theme.getPaint("BackgroundTertiary")
@@ -216,138 +197,49 @@ class Menu {
         this.mainBox.show();
 
         // sets pos of buttons        
-        this.markTaskDoneButton.position(pos.x + MENU_X_OFFSET + 7, pos.y + MENU_Y_OFFSET + 7);
-        this.editTaskButton.position(pos.x + MENU_X_OFFSET + 7, pos.y + MENU_Y_OFFSET + 30);
-        this.deleteTaskButton.position(pos.x + MENU_X_OFFSET + 7, pos.y + MENU_Y_OFFSET + 53);
-        this.moveTaskUpButton.position(pos.x + MENU_X_OFFSET + 7, pos.y + MENU_Y_OFFSET + 76);
-        this.moveTaskDownButton.position(pos.x + MENU_X_OFFSET + 41, pos.y + MENU_Y_OFFSET + 76);
-
-        let buttons = [
-            this.markTaskDoneButton,
-            this.editTaskButton,
-            this.deleteTaskButton,
-            this.moveTaskUpButton,
-            this.moveTaskDownButton
+        let positions = [
+            {x: 7, y: 7},
+            {x: 7, y: 30},
+            {x: 7, y: 53},
+            {x: 7, y: 76},
+            {x: 41, y: 76},
         ]
-        
+
         let bgClr = theme.getPaint("BackgroundSecondary")
         let textClr = theme.getPaint("TextPrimary")
         let strokeClr = theme.getPaint("StrokePrimary")
-        for (let btn of buttons) {
+
+        let loops = 0
+        for (let btn of this.buttons) {
+            btn.position(pos.x + MENU_X_OFFSET + positions[loops].x, pos.y + MENU_Y_OFFSET + positions[loops].y)
             btn.show()
             btn.style('z-index', '3')
             btn.style('position', 'absolute')
             btn.style("background-color", bgClr.getHex()); 
             btn.style("color", textClr.getHex()); 
             btn.style("border", "2px solid" + strokeClr.getHex()); 
+            loops++
         }
     }
 
-    showListMenu() {
-
-        if (!this.listMenuOpen) {
-            return;
-        }
-        let bgColor = theme.getPaint("BackgroundTertiary")
-        let borderColor = theme.getPaint("StrokeSecondary")
-        const pos = { x: this.parent.x, y: this.y };
-
-        // main box
-        this.mainBox.position(pos.x + LIST_MENU_X_OFFSET, pos.y + LIST_MENU_Y_OFFSET);
-        this.mainBox.style(`width: ${[this.width]}px`);
-        this.mainBox.style(`height: ${[this.height]}px`);
-        this.mainBox.style("z-index: 2");
-        if (mode === "default") {
-            this.mainBox.style(`background-color: ${bgColor.getHex()}`);
-            this.mainBox.style(`border: 3px solid ${borderColor.getHex()}`);
-        } else if (mode === "dark") {
-            this.mainBox.style(`background-color: ${bgColor.toDarkMode().getHex()}`);
-            this.mainBox.style(`border: 3px solid ${borderColor.getHex()}`);
-        }
-
-        this.mainBox.style(`border-radius: 10px`);
-        this.mainBox.show();
-
-        // sets pos of buttons
-        this.addTaskButton.position(pos.x + LIST_MENU_X_OFFSET + 7, pos.y + LIST_MENU_Y_OFFSET + 7);
-        this.deleteListButton.position(pos.x + LIST_MENU_X_OFFSET + 7, pos.y + LIST_MENU_Y_OFFSET + 30);
-        this.editListButton.position(pos.x + LIST_MENU_X_OFFSET + 7, pos.y + LIST_MENU_Y_OFFSET + 53);
-
-        //show move task up/down buttons
-        this.addTaskButton.show();
-        this.deleteListButton.show();
-        this.editListButton.show();
-
-        //menu buttons style.
-        this.addTaskButton.style('z-index', '3');
-        this.deleteListButton.style('z-index', '3');
-        this.editListButton.style('z-index', '3');
-
-        //menu buttons position style.
-        this.addTaskButton.style('position', 'absolute');
-        this.deleteListButton.style('position', 'absolute');
-        this.editListButton.style('position', 'absolute');
-        let buttons = [
-            this.markTaskDoneButton,
-            this.editTaskButton,
-            this.deleteTaskButton,
-            this.moveTaskUpButton,
-            this.moveTaskDownButton
-        ]
-        
-        let bgClr = theme.getPaint("BackgroundSecondary")
-        let textClr = theme.getPaint("TextPrimary")
-        let strokeClr = theme.getPaint("StrokePrimary")
-        for (let btn of buttons) {
-            btn.show()
-            btn.style('z-index', '3')
-            btn.style('position', 'absolute')
-            btn.style("background-color", bgClr.getHex()); 
-            btn.style("color", textClr.getHex()); 
-            btn.style("border", "2px solid" + strokeClr.getHex()); 
+    hideButtons() {
+        for (let btn of this.buttons) {
+            btn.hide()
         }
     }
-
-    hideMenuButtons() {
-        this.markTaskDoneButton.hide();
-        this.deleteTaskButton.hide();
-        this.editTaskButton.hide();
-        this.moveTaskUpButton.hide();
-        this.moveTaskDownButton.hide();
-        this.mainBox.hide();
-    }
-
-    hideListMenuButtons(){
-        this.addTaskButton.hide();
-        this.deleteListButton.hide();
-        this.editListButton.hide();
-        this.mainBox.hide();
-    }
-
     
-
     editTask(){
         let editName = prompt("Input new task name:", this.parent.name);
-        switch(editName){
-            case null:
-                return;
-                break;
-
-            default:
-                this.parent.name = editName;
-                saveAllLists();
+        if (!editName) {
+            return
         }
+        this.parent.name = editName;
 
         let editDesc = prompt("Input new task description:", this.parent.description);
-        switch(editDesc){
-            case null:
-                saveAllLists();
-                return;
-                break;
 
-            default:
-                this.parent.description = editDesc;
-                saveAllLists();
+        if (!editDesc) {
+            saveAllLists();
+            return;
         }
 
         this.parent.description = editDesc;
@@ -380,9 +272,10 @@ class Menu {
     getListTask() {
         for (let list of listArray) {
             let storage = list.getStorage();
-            if (storage.findIndex(task => task.id === this.parent.id) != -1) {
-                return list;
+            if (storage.findIndex(task => task.id === this.parent.id) == -1) {
+                continue
             }
+            return list;
         }
     }
 

--- a/Classes/Paint.js
+++ b/Classes/Paint.js
@@ -3,14 +3,9 @@ const DEFAULT_RED        = 0
 const DEFAULT_GREEN      = 0
 const DEFAULT_BLUE       = 0
 
-const HEX_VALUES = [
-    "A",
-    "B",
-    "C",
-    "D",
-    "E",
-    "F"
-]
+const HEX_DIGITS = 16; //switch this to break everything
+
+const ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 class Paint {
     //supports a single argument better c:
@@ -25,8 +20,33 @@ class Paint {
     setBlue(newBlue)   { this.B = newBlue  || DEFAULT_BLUE }
 
     //instead of passing in numbers for the color() thing pass this in (yes this is tested and works)
-    getColor() {
+    getRGB() {
         return [this.R, this.G, this.B];
+    }
+    
+    //just in case...
+    getHex() {
+        let hexString = "#" //remove # if its not needed
+
+        for (let rgb of this.getRGB()) { //gets all 3 values
+            for (let i = 1; i <= 2; i ++) {
+                let hexVal
+                if (i % 2 == 1) {
+                    hexVal = Math.floor(rgb / HEX_DIGITS)
+                } else {
+                    hexVal = rgb % HEX_DIGITS
+                }
+
+                if (hexVal > 9) {
+                    hexVal -= 10
+                    hexVal = ALPHABET.substring(hexVal, hexVal + 1)
+                }
+
+                hexString += hexVal + ""
+            }
+        }
+        
+        return hexString
     }
 
     toSaveString() {
@@ -93,7 +113,7 @@ class Paint {
        
         let colorVals = []
         
-        for (let colorVal of this.getColor()) {
+        for (let colorVal of this.getRGB()) {
           // console.log(Math.sqrt(colorVal))
           let newVal = Math.abs(colorVal + colorDiff)
           
@@ -103,35 +123,7 @@ class Paint {
         return new Paint(colorVals[0], colorVals[1], colorVals[2])
     }
 
-    //just in case...
-    toHex() {
-        let hexString = "#" //remove # if its not needed
-
-        for (let rgb of this.getColor()) { //gets all 3 values
-            let val1 = Math.floor(rgb / 16)
-            let val2 = rgb % 16
-
-            if (val1 > 9) {
-                val1 = HEX_VALUES[val1 - 10]
-            }
-            if (val2 > 9) {
-                val2 = HEX_VALUES[val2 - 10]
-            }
-
-            hexString += val1 + ""
-            hexString += val2 + ""
-        }
-        
-        return hexString
-    }
-
-    //no clue why anyone would use p5 colors over this but whatever (transparency or something?)
-    toP5Color() {
-        return color(this.R, this.G, this.B)
-    }
 }
-
-
 
 function parseColor(colorString) {
     if (!colorString) {

--- a/Classes/Task.js
+++ b/Classes/Task.js
@@ -131,7 +131,7 @@ class Task {
             ctx.shadowColor = theme.getPaint("Glow").getHex();
             ctx.shadowOffsetX = 0.7;
             ctx.shadowOffsetY = 0.7;
-            ctx.shadowBlur = 1;
+            ctx.shadowBlur = 1 * theme.getData("GlowIntensity");
         }
 
         let strokeColor = theme.getPaint("StrokeSecondary")
@@ -179,17 +179,20 @@ class Task {
         menu.menuButton.show();
 
         // text highlight
-        let highlightOpacity = 22; // scale of 0-100
-        textSize(NAME_SIZE);
-        let highlightMargin = 5;
-        let highlightWidth = 380 - highlightMargin * 2;
-        let highlightHeight = 120 * 0.38 - highlightMargin;
-        //let highlightWidth = textWidth(this.name) + highlightMargin;
-        //let highlightHeight = textAscent(this.name) * 0.2 + highlightMargin;
-        noStroke()
-        fill(255,255,255,highlightOpacity);
-        rect(x + highlightMargin, y + highlightMargin, highlightWidth, highlightHeight, 10)
-
+        if (theme.getData("HighlightEnabled")) {
+            console.log(theme.getData("HighlightEnabled"))
+            let highlightColor = theme.getPaint("HighlightColor")
+            let highlightOpacity = 22; // scale of 0-100
+            textSize(NAME_SIZE);
+            let highlightMargin = 5;
+            let highlightWidth = 380 - highlightMargin * 2;
+            let highlightHeight = 120 * 0.38 - highlightMargin;
+            //let highlightWidth = textWidth(this.name) + highlightMargin;
+            //let highlightHeight = textAscent(this.name) * 0.2 + highlightMargin;
+            noStroke()
+            fill(highlightColor.R, highlightColor.G, highlightColor.B, highlightOpacity);
+            rect(x + highlightMargin, y + highlightMargin, highlightWidth, highlightHeight, 10)
+        }
         
         strokeWeight(0); //i really do not like using stroke on text, it looks SOOO ugly
         // text slop
@@ -213,7 +216,7 @@ class Task {
         //fill(DEFAULT_WHITE.getRGB());
         //strokeWeight(1);
 
-        this.menu.showTaskMenu();
+        this.menu.showMenu();
     }
 
     static fromJSON(data) {

--- a/Classes/Task.js
+++ b/Classes/Task.js
@@ -54,8 +54,8 @@ class Task {
         this.id          = id       || Math.floor(Date.now() / ((Math.random() * 10000) + 500));
         // this.id          = id       || GenerateId();  
 
-        //let menuBg = this.bgColor.getColor()
-        //let menuStroke = STROKE_COLOR.getColor()
+        //let menuBg = this.bgColor.getRGB()
+        //let menuStroke = STROKE_COLOR.getRGB()
 
         this.menu = new Menu(
             0,
@@ -126,15 +126,18 @@ class Task {
   
     show(x, y) {
         let ctx = drawingContext
-        ctx.shadowColor = theme.getColor("Glow").toHex();
-        ctx.shadowOffsetX = 0.7;
-        ctx.shadowOffsetY = 0.7;
-        ctx.shadowBlur = 1;
 
-        let strokeColor = theme.getColor("StrokeSecondary")
-        let nameColor = theme.getColor("TextSecondary")
-        let descColor = theme.getColor("TextTertiary")
-        let bgColor = theme.getColor("BackgroundTertiary")
+        if (theme.getData("GlowEnabled")) {
+            ctx.shadowColor = theme.getPaint("Glow").getHex();
+            ctx.shadowOffsetX = 0.7;
+            ctx.shadowOffsetY = 0.7;
+            ctx.shadowBlur = 1;
+        }
+
+        let strokeColor = theme.getPaint("StrokeSecondary")
+        let nameColor = theme.getPaint("TextSecondary")
+        let descColor = theme.getPaint("TextTertiary")
+        let bgColor = theme.getPaint("BackgroundTertiary")
 
         let menu = this.menu
 
@@ -146,12 +149,12 @@ class Task {
 
         // main box
         strokeWeight(3);
-        stroke(strokeColor.getColor());
+        stroke(strokeColor.getRGB());
         push();
         if (mode === "default") {
-            fill(bgColor.getColor());
+            fill(bgColor.getRGB());
         } else if (mode === "dark") {
-            fill(bgColor.toDarkMode().getColor());
+            fill(bgColor.toDarkMode().getRGB());
         }
         rect(x, y, 380, 120, 10); // why aren't these constants?!
         pop();
@@ -164,13 +167,13 @@ class Task {
         menu.menuButton.position(x + 345, y + 7);
 
         //styles the menu button
-        let buttonBg = theme.getColor("BackgroundSecondary")
-        let buttonText = theme.getColor("TextPrimary")
-        let buttonStroke = theme.getColor("StrokePrimary")
+        let buttonBg = theme.getPaint("BackgroundSecondary")
+        let buttonText = theme.getPaint("TextPrimary")
+        let buttonStroke = theme.getPaint("StrokePrimary")
 
-        menu.menuButton.style("background-color", buttonBg.toHex()); 
-        menu.menuButton.style("color", buttonText.toHex()); 
-        menu.menuButton.style("border", "2px solid" + buttonStroke.toHex()); 
+        menu.menuButton.style("background-color", buttonBg.getHex()); 
+        menu.menuButton.style("color", buttonText.getHex()); 
+        menu.menuButton.style("border", "2px solid" + buttonStroke.getHex()); 
 
         //show move task up/down buttons
         menu.menuButton.show();
@@ -190,24 +193,24 @@ class Task {
         
         strokeWeight(0); //i really do not like using stroke on text, it looks SOOO ugly
         // text slop
-        textFont(theme.getFont());
+        textFont(theme.getData("Font"));
         //name
         textAlign(CENTER, CENTER);
-        fill(nameColor.getColor());
+        fill(nameColor.getRGB());
         textSize(NAME_SIZE);
         text(this.name, x + TEXT_X_OFFSET, y + TEXT_Y_PADDING);
 
         //desc
-        fill(descColor.getColor());
+        fill(descColor.getRGB());
         textSize(DESC_SIZE);
         text(this.description, x + TEXT_X_OFFSET, y + TEXT_Y_PADDING * 2);
 
         //status
-        fill(STATUS_COLORS[this.status].getColor() || STATUS_COLORS["Default"].getColor());
+        fill(STATUS_COLORS[this.status].getRGB() || STATUS_COLORS["Default"].getRGB());
         textSize(STATUS_SIZE);
         text(this.status, x + TEXT_X_OFFSET, y + TEXT_Y_PADDING * 3);
 
-        //fill(DEFAULT_WHITE.getColor());
+        //fill(DEFAULT_WHITE.getRGB());
         //strokeWeight(1);
 
         this.menu.showTaskMenu();

--- a/Classes/Task.js
+++ b/Classes/Task.js
@@ -182,7 +182,7 @@ class Task {
         if (theme.getData("HighlightEnabled")) {
             console.log(theme.getData("HighlightEnabled"))
             let highlightColor = theme.getPaint("HighlightColor")
-            let highlightOpacity = 22; // scale of 0-100
+            let highlightOpacity = theme.getData("HighlightOpacity"); // scale of 0-100
             textSize(NAME_SIZE);
             let highlightMargin = 5;
             let highlightWidth = 380 - highlightMargin * 2;

--- a/Classes/Theme.js
+++ b/Classes/Theme.js
@@ -1,27 +1,28 @@
 class Theme {
-    constructor(tP, tS, tT, sP, sS, bP, bS, bT, g, font) { //ik how much i stress readability but i am NOT typing allat
+    constructor(data) { //ik how much i stress readability but i am NOT typing allat
         //text slop
-        this.TextPrimary         = tP   || new Paint()
-        this.TextSecondary       = tS   || new Paint()
-        this.TextTertiary        = tT   || new Paint(200,200,200)
+        this.TextPrimary         = data.TextPrimary          || new Paint()
+        this.TextSecondary       = data.TextSecondary        || new Paint()
+        this.TextTertiary        = data.TextTertiary         || new Paint(200,200,200)
 
         //stroke
-        this.StrokePrimary       = sP   || new Paint(100, 230, 255)
-        this.StrokeSecondary     = sS   || new Paint(100, 230, 255)
+        this.StrokePrimary       = data.StrokePrimary        || new Paint(100, 230, 255)
+        this.StrokeSecondary     = data.StrokeSecondary      || new Paint(100, 230, 255)
 
         //background
-        this.BackgroundPrimary   = bP   || new Paint(200,200,200)
-        this.BackgroundSecondary = bS   || new Paint(255,255,255)
-        this.BackgroundTertiary  = bT   || new Paint(58, 110, 165)
+        this.BackgroundPrimary   = data.BackgroundPrimary    || new Paint(200,200,200)
+        this.BackgroundSecondary = data.BackgroundSecondary  || new Paint(255,255,255)
+        this.BackgroundTertiary  = data.BackgroundTertiary   || new Paint(58, 110, 165)
 
         //glow/shadow
-        this.Glow = g                   || new Paint(0,0,0)
+        this.Glow                = data.Glow                 || new Paint(0,0,0)
 
-        //font
-        this.Font                = font || "Arial"
+        //misc data
+        this.Font                = data.Font                 || "Arial"
+        this.GlowEnabled         = data.GlowEnabled          || true
     }
 
-    getColor(colorName) {
+    getPaint(colorName) {
         let colorVal = this[colorName] //either a Paint or a list of paints
 
         if (colorVal instanceof Paint) {
@@ -35,7 +36,11 @@ class Theme {
         return colorVal[randInt]
     }
 
-    getFont() {
+    getData(dataName) {
+        if (!this[dataName]) {
+            throw new Error(`${dataName} is not a member of this theme!`);
+            
+        }
         return this.Font
     }
 
@@ -72,28 +77,9 @@ class Theme {
 }
 
 const PresetThemes = {
-    Default: new Theme(
-        new Paint(),             //TextPrimary
-        new Paint(),             //TextSecondary
-        new Paint(200,200,200),  //TextTertiary
-        new Paint(100, 230, 255),//StrokePrimary
-        new Paint(100, 230, 255),//StrokeSecondary
-        new Paint(200,200,200),  //BackgroundPrimary
-        new Paint(255,255,255),  //BackgroundSecondary
-        new Paint(58, 110, 165), //BackgroundTertiary
-        new Paint(0, 0, 0),       //Glow
-        "Arial"                  //Font
-    ),
-    Classic: new Theme(
-        new Paint(),             //TextPrimary
-        new Paint(),             //TextSecondary
-        new Paint(200,200,200),  //TextTertiary
-        new Paint(100, 230, 255),//StrokePrimary
-        new Paint(100, 230, 255),//StrokeSecondary
-        new Paint(200,200,200),  //BackgroundPrimary
-        new Paint(255,255,255),  //BackgroundSecondary
-        //BackgroundTertiary
-        [
+    Default: new Theme(),
+    Classic: new Theme({
+        BackgroundTertiary: [
             new Paint(58, 110, 165), 
             // new Paint(192), 
             // new Paint(161, 130, 118), 
@@ -105,82 +91,93 @@ const PresetThemes = {
             // new Paint(58, 90, 64), 
             // new Paint(52, 78, 65)
         ],
-        new Paint(0, 0, 0),      //Glow
-        "Courier New"            //Font
-    ),
-    Sakura: new Theme(
-        new Paint(255, 229, 236),//TextPrimary
-        new Paint(251, 111, 146),//TextSecondary
-        new Paint(82, 50, 20),   //TextTertiary
-        new Paint(71, 49, 27),   //StrokePrimary
-        new Paint(255, 179, 198),//StrokeSecondary
-        new Paint(255, 194, 209),//BackgroundPrimary
-        new Paint(82, 53, 25),   //BackgroundSecondary
-        new Paint(255, 229, 236),//BackgroundTertiary
-        new Paint(0, 0, 0),       //Glow
-        "Arial"                  //Font
-    ),
+        Font: "Courier New",
+        GlowEnabled: false
+    }),
+    Sakura: new Theme({
+        TextPrimary: new Paint(255, 229, 236),
+        TextSecondary: new Paint(251, 111, 146),
+        TextTertiary: new Paint(82, 50, 20),   
+        StrokePrimary: new Paint(71, 49, 27),   
+        StrokeSecondary: new Paint(255, 179, 198),
+        BackgroundPrimary: new Paint(255, 194, 209),
+        BackgroundSecondary: new Paint(82, 53, 25),   
+        BackgroundTertiary: new Paint(255, 229, 236),
+        Glow: new Paint(0, 0, 0),      
+        Font: "Arial"                  
+    }),
     //TODO: MY DELICATE RETINAS!!!! THEY BURN!!!!!
-    SakuraPrime: new Theme( 
-        new Paint(),             //TextPrimary
-        new Paint(),             //TextSecondary
-        new Paint(255, 117, 239),//TextTertiary
-        new Paint(255, 161, 244),//StrokePrimary
-        new Paint(255, 161, 244),//StrokeSecondary
-        new Paint(255, 255, 255),//BackgroundPrimary
-        new Paint(255, 117, 239),//BackgroundSecondary
-        new Paint(255, 255, 255),//BackgroundTertiary
-        new Paint(255, 0, 255),  //Glow
-        "Arial"                  //Font
-    ),
-    V1sDream: new Theme(
-        new Paint(10, 30, 52), //TextPrimary
-        new Paint(189, 31, 54),//TextSecondary
-        new Paint(178, 30, 53),//TextTertiary
-        new Paint(133, 24, 42),//StrokeSecondary
-        new Paint(100, 18, 32),//StrokePrimary
-        new Paint(110, 20, 35),//BackgroundPrimary
-        new Paint(199, 31, 55),//BackgroundSecondary
-        new Paint(100, 18, 32),//BackgroundTertiary
-        new Paint(255, 0, 0),  //Glow
-        "Arial",               //Font
-    ),
-    DeepBlue: new Theme(
-        new Paint(70, 143, 175),//TextPrimary
-        new Paint(),            //TextSecondary
-        new Paint(100,100,100), //TextTertiary
-        new Paint(),            //StrokePrimary
-        new Paint(97, 165, 194),//StrokeSecondary
-        new Paint(1, 58, 99),   //BackgroundPrimary
-        new Paint(1, 42, 74),   //BackgroundSecondary
-        new Paint(1, 73, 124),  //BackgroundTertiary
-        new Paint(0, 0, 0),     //Glow
-        "Arial",                //Font
-    ),
-    "1x1x1x1": new Theme(
-        new Paint(255,0,0),      //TextPrimary
-        new Paint(255, 0, 0),    //TextSecondary
-        new Paint(175, 175, 175),//TextTertiary
-        new Paint(0, 140, 0),    //StrokePrimary
-        new Paint(10, 175, 10),  //StrokeSecondary
-        new Paint(),             //BackgroundPrimary
-        new Paint(11, 101, 11),  //BackgroundSecondary
-        new Paint(0, 0, 0),      //BackgroundTertiary
-        new Paint(0, 255, 0),    //Glow
-        "Arial"                  //Font
-    ),
-    UltraGreen: new Theme(
-        new Paint(0, 114, 0),   //TextPrimary
-        new Paint(0, 100, 0),   //TextSecondary
-        new Paint(0, 75, 35),   //TextTertiary
-        new Paint(56, 176, 0),  //StrokePrimary
-        new Paint(0, 128, 0),   //StrokeSecondary
-        new Paint(204, 255, 51),//BackgroundPrimary
-        new Paint(158, 240, 26),//BackgroundSecondary
-        new Paint(112, 224, 0), //BackgroundTertiary
-        new Paint(0, 255, 0),     //Glow
-        "Arial",                //Font
-    ),
+    SakuraPrime: new Theme({ 
+        TextPrimary: new Paint(),             
+        TextSecondary: new Paint(),             
+        TextTertiary: new Paint(255, 117, 239),
+        StrokePrimary: new Paint(255, 161, 244),
+        StrokeSecondary: new Paint(255, 161, 244),
+        BackgroundPrimary: new Paint(255, 255, 255),
+        BackgroundSecondary: new Paint(255, 117, 239),
+        BackgroundTertiary: new Paint(255, 255, 255),
+        Glow: new Paint(255, 0, 255),  
+        Font: "Arial"                  
+    }),
+    V1sDream: new Theme({
+        TextPrimary: new Paint(10, 30, 52), 
+        TextSecondary: new Paint(189, 31, 54),
+        TextTertiary: new Paint(178, 30, 53),
+        StrokeSecondary: new Paint(133, 24, 42),
+        StrokePrimary: new Paint(100, 18, 32),
+        BackgroundPrimary: new Paint(110, 20, 35),
+        BackgroundSecondary: new Paint(199, 31, 55),
+        BackgroundTertiary: new Paint(100, 18, 32),
+        Glow: new Paint(255, 0, 0),  
+        Font: "Arial",               
+    }),
+    DeepBlue: new Theme({
+        TextPrimary: new Paint(70, 143, 175),
+        TextSecondary: new Paint(),            
+        TextTertiary: new Paint(100,100,100), 
+        StrokePrimary: new Paint(),            
+        StrokeSecondary: new Paint(97, 165, 194),
+        BackgroundPrimary: new Paint(1, 58, 99),   
+        BackgroundSecondary: new Paint(1, 42, 74),   
+        BackgroundTertiary: new Paint(1, 73, 124),  
+        Glow: new Paint(0, 0, 0),     
+        Font: "Arial",                
+    }),
+    "1x1x1x1": new Theme({
+        TextPrimary: new Paint(255,0,0),      
+        TextSecondary: new Paint(255, 0, 0),    
+        TextTertiary: new Paint(175, 175, 175),
+        StrokePrimary: new Paint(0, 140, 0),    
+        StrokeSecondary: new Paint(10, 175, 10),  
+        BackgroundPrimary: new Paint(),             
+        BackgroundSecondary: new Paint(11, 101, 11),  
+        BackgroundTertiary: new Paint(0, 0, 0),      
+        Glow: new Paint(0, 255, 0),    
+        Font: "Arial"                  
+    }),
+    UltraGreen: new Theme({
+        TextPrimary: new Paint(0, 114, 0),   
+        TextSecondary: new Paint(0, 100, 0),   
+        TextTertiary: new Paint(0, 75, 35),   
+        StrokePrimary: new Paint(56, 176, 0),  
+        StrokeSecondary: new Paint(0, 128, 0),   
+        BackgroundPrimary: new Paint(204, 255, 51),
+        BackgroundSecondary: new Paint(158, 240, 26),
+        BackgroundTertiary: new Paint(112, 224, 0), 
+        Glow: new Paint(0, 255, 0),   
+        Font: "Arial",                
+    }),
+    SmileOS: new Theme({
+        TextPrimary: new Paint(255,255,255),
+        TextSecondary: new Paint(255,255,255),
+        TextTertiary: new Paint(255,255,255),
+        StrokePrimary: new Paint(255,255,255),
+        StrokeSecondary: new Paint(255,255,255),
+        BackgroundPrimary: new Paint(0,0,0),
+        BackgroundSecondary: new Paint(0,0,0),
+        BackgroundTertiary: new Paint(0,0,0),
+        GlowEnabled: false
+    })
 }
 
 function getPresetTheme(presetName) {

--- a/Classes/Theme.js
+++ b/Classes/Theme.js
@@ -1,5 +1,8 @@
 class Theme {
-    constructor(data) { //ik how much i stress readability but i am NOT typing allat
+    constructor(data) {
+        if (!data) {
+            data = {}
+        }
         //text slop
         this.TextPrimary         = data.TextPrimary          || new Paint()
         this.TextSecondary       = data.TextSecondary        || new Paint()
@@ -16,10 +19,16 @@ class Theme {
 
         //glow/shadow
         this.Glow                = data.Glow                 || new Paint(0,0,0)
+        this.GlowIntensity       = data.GlowIntensity        || 1
+        this.GlowEnabled         = data.GlowEnabled          || false
+
+        //highlight
+        this.HighlightColor      = data.HighlightColor       || new Paint(255,255,255)
+        this.HighlightEnabled    = data.HighlightEnabled     || false
+        this.HighlightOpacity    = data.HighlightOpacity     || 22
 
         //misc data
         this.Font                = data.Font                 || "Arial"
-        this.GlowEnabled         = data.GlowEnabled          || true
     }
 
     getPaint(colorName) {
@@ -31,17 +40,12 @@ class Theme {
 
         //pick random if its a list
         let randInt = Math.floor(Math.random() * colorVal.length)
-        console.log(randInt)
 
         return colorVal[randInt]
     }
 
     getData(dataName) {
-        if (!this[dataName]) {
-            throw new Error(`${dataName} is not a member of this theme!`);
-            
-        }
-        return this.Font
+        return this[dataName]
     }
 
     //might be redundant later due to custom dark themes
@@ -77,7 +81,10 @@ class Theme {
 }
 
 const PresetThemes = {
-    Default: new Theme(),
+    Default: new Theme({
+        GlowEnabled: true,
+        HighlightEnabled: true
+    }),
     Classic: new Theme({
         BackgroundTertiary: [
             new Paint(58, 110, 165), 
@@ -92,7 +99,8 @@ const PresetThemes = {
             // new Paint(52, 78, 65)
         ],
         Font: "Courier New",
-        GlowEnabled: false
+        GlowEnabled: false,
+        HighlightEnabled: false
     }),
     Sakura: new Theme({
         TextPrimary: new Paint(255, 229, 236),
@@ -103,8 +111,8 @@ const PresetThemes = {
         BackgroundPrimary: new Paint(255, 194, 209),
         BackgroundSecondary: new Paint(82, 53, 25),   
         BackgroundTertiary: new Paint(255, 229, 236),
-        Glow: new Paint(0, 0, 0),      
-        Font: "Arial"                  
+        GlowEnabled: true,
+        HighlightEnabled: true
     }),
     //TODO: MY DELICATE RETINAS!!!! THEY BURN!!!!!
     SakuraPrime: new Theme({ 
@@ -117,7 +125,9 @@ const PresetThemes = {
         BackgroundSecondary: new Paint(255, 117, 239),
         BackgroundTertiary: new Paint(255, 255, 255),
         Glow: new Paint(255, 0, 255),  
-        Font: "Arial"                  
+        GlowIntensity: 10,
+        GlowEnabled: true,
+        HighlightEnabled: true
     }),
     V1sDream: new Theme({
         TextPrimary: new Paint(10, 30, 52), 
@@ -129,7 +139,10 @@ const PresetThemes = {
         BackgroundSecondary: new Paint(199, 31, 55),
         BackgroundTertiary: new Paint(100, 18, 32),
         Glow: new Paint(255, 0, 0),  
-        Font: "Arial",               
+        HighlightColor: new Paint(255,0,0),
+        GlowIntensity: 5,
+        GlowEnabled: true,
+        HighlightEnabled: true
     }),
     DeepBlue: new Theme({
         TextPrimary: new Paint(70, 143, 175),
@@ -140,8 +153,8 @@ const PresetThemes = {
         BackgroundPrimary: new Paint(1, 58, 99),   
         BackgroundSecondary: new Paint(1, 42, 74),   
         BackgroundTertiary: new Paint(1, 73, 124),  
-        Glow: new Paint(0, 0, 0),     
-        Font: "Arial",                
+        GlowEnabled: true,
+        HighlightEnabled: true
     }),
     "1x1x1x1": new Theme({
         TextPrimary: new Paint(255,0,0),      
@@ -153,7 +166,9 @@ const PresetThemes = {
         BackgroundSecondary: new Paint(11, 101, 11),  
         BackgroundTertiary: new Paint(0, 0, 0),      
         Glow: new Paint(0, 255, 0),    
-        Font: "Arial"                  
+        GlowIntensity: 10,
+        GlowEnabled: true,
+        HighlightEnabled: false
     }),
     UltraGreen: new Theme({
         TextPrimary: new Paint(0, 114, 0),   
@@ -165,7 +180,8 @@ const PresetThemes = {
         BackgroundSecondary: new Paint(158, 240, 26),
         BackgroundTertiary: new Paint(112, 224, 0), 
         Glow: new Paint(0, 255, 0),   
-        Font: "Arial",                
+        GlowEnabled: true,
+        HighlightEnabled: true
     }),
     SmileOS: new Theme({
         TextPrimary: new Paint(255,255,255),
@@ -176,7 +192,8 @@ const PresetThemes = {
         BackgroundPrimary: new Paint(0,0,0),
         BackgroundSecondary: new Paint(0,0,0),
         BackgroundTertiary: new Paint(0,0,0),
-        GlowEnabled: false
+        GlowEnabled: false,
+        HighlightEnabled: false
     })
 }
 

--- a/Classes/Theme.js
+++ b/Classes/Theme.js
@@ -85,6 +85,20 @@ const PresetThemes = {
         GlowEnabled: true,
         HighlightEnabled: true
     }),
+    DarkMode: new Theme({
+        TextPrimary: new Paint(200,200,200),
+        TextSecondary: new Paint(200,200,200),
+        TextTertiary: new Paint(225,225,225),
+        BackgroundPrimary: new Paint(25,25,25),
+        BackgroundSecondary: new Paint(50,50,50),
+        BackgroundTertiary: new Paint(8, 60, 105),
+        StrokePrimary: new Paint(25, 155, 180),
+        StrokeSecondary: new Paint(25, 155, 180),
+        GlowEnabled: true,
+        HighlightColor: new Paint(),
+        HighlightOpacity: 44,
+        HighlightEnabled: true
+    }),
     Classic: new Theme({
         BackgroundTertiary: [
             new Paint(58, 110, 165), 
@@ -142,6 +156,7 @@ const PresetThemes = {
         HighlightColor: new Paint(255,0,0),
         GlowIntensity: 5,
         GlowEnabled: true,
+        HighlightOpacity: 60,
         HighlightEnabled: true
     }),
     DeepBlue: new Theme({
@@ -194,6 +209,32 @@ const PresetThemes = {
         BackgroundTertiary: new Paint(0,0,0),
         GlowEnabled: false,
         HighlightEnabled: false
+    }),
+    HackerMan: new Theme({
+        TextPrimary: new Paint(0,255,0),
+        TextSecondary: new Paint(0,255,0),
+        TextTertiary: new Paint(0,255,0),
+        StrokePrimary: new Paint(0,255,0),
+        StrokeSecondary: new Paint(0,255,0),
+        BackgroundPrimary: new Paint(0,0,0),
+        BackgroundSecondary: new Paint(0,0,0),
+        BackgroundTertiary: new Paint(0,0,0),
+        Glow: new Paint(0,255,0),
+        GlowIntensity: 10,
+        GlowEnabled: true,
+        HighlightEnabled: false
+    }),
+    Noob: new Theme({
+        TextPrimary: new Paint(0,0,0),
+        TextSecondary: new Paint(0,0,0),
+        TextTertiary: new Paint(0,0,0),
+        StrokePrimary: new Paint(0,0,0),
+        StrokeSecondary: new Paint(0,0,0),
+        BackgroundPrimary: new Paint(255, 225, 0),
+        BackgroundSecondary: new Paint(0, 157, 255),
+        BackgroundTertiary: new Paint(13, 133, 0),
+        GlowEnabled: true,
+        HighlightEnabled: true
     })
 }
 

--- a/sketch.js
+++ b/sketch.js
@@ -31,10 +31,15 @@ function setup() {
   }
 }
 
+//as of now the draw function will stay but some other day it wont exist (idk if Element.mouseOver works with this anyway)
 function draw() {
-  let bgColor = theme.getColor("BackgroundPrimary")
+  update()
+}
+
+function update() {
+  let bgColor = theme.getPaint("BackgroundPrimary")
   if (mode === "default") {
-    background(bgColor.getColor());
+    background(bgColor.getRGB());
   } else if (mode === "dark") {
     let evilBg = bgColor.toDarkMode()
     background(evilBg);
@@ -68,7 +73,6 @@ function showLists() {
   }
 }
 
-
 // If the window size changes, automatically resize the canvas to fill the browser window
 function windowResized() {
   resizeCanvas(windowWidth, windowHeight);
@@ -101,13 +105,13 @@ function getNewList(){
 }
 
 function styleButton(btn) {
-  let bgClr = theme.getColor("BackgroundTertiary")
-  let textClr = theme.getColor("TextSecondary")
-  let strokeClr = theme.getColor("StrokeSecondary")
+  let bgClr = theme.getPaint("BackgroundTertiary")
+  let textClr = theme.getPaint("TextSecondary")
+  let strokeClr = theme.getPaint("StrokeSecondary")
 
-  btn.style("background-color", bgClr.toHex()); 
-  btn.style("color", textClr.toHex()); 
-  btn.style("border", "2px solid" + strokeClr.toHex()); 
+  btn.style("background-color", bgClr.getHex()); 
+  btn.style("color", textClr.getHex()); 
+  btn.style("border", "2px solid" + strokeClr.getHex()); 
   btn.style("padding", "8px 16px");
   btn.style("border-radius", "6px");
   btn.style("font-size", "14px");


### PR DESCRIPTION
- Fixed a crucial issue for hamburger menus on lists 
- Extremely significant changes and improvements to Menu (so many it caused a load diff)
- Improved the code of Paint's "toHex" method
- Needlessly expanded capability of Paint's "toHex" method for the investors (counts up to 36 in one digit)
- Renamed Paint's "getColor" and "toHex" methods to "getRGB" and "getHex" (makes cents)
- Changed Theme's constructor to scale easier as more features are added
- New themes: DarkMode, SmileOS, HackerMan, and Noob
- 6 or 7 new theme settings (to do with glows and highlights)
- Strengthened glow on 1x1x1x1, SakuraPrime, and V1sDream
- Removed TaskAI for destroying the codebase again